### PR TITLE
Use rollup-plugin-invariant to import process polyfill automatically.

### DIFF
--- a/packages/rollup-plugin-invariant/src/plugin.ts
+++ b/packages/rollup-plugin-invariant/src/plugin.ts
@@ -26,9 +26,7 @@ export default function invariantPlugin(options = {} as any) {
             })
           ) {
             path.get("specifiers").push(
-              b.importSpecifier(
-                b.identifier("process"),
-              ),
+              b.importSpecifier(b.identifier("process")),
             );
           }
         },

--- a/packages/rollup-plugin-invariant/src/tests.ts
+++ b/packages/rollup-plugin-invariant/src/tests.ts
@@ -177,5 +177,27 @@ describe("rollup-plugin-invariant", function () {
     `, {
       importProcessPolyfill: true,
     });
+
+    checkTransform(`
+      import { foo } from "bar";
+      import invariant from "ts-invariant";
+      invariant(true, "ok");
+    `, `
+      import { foo } from "bar";
+      import invariant, { process } from "ts-invariant";
+      process.env.NODE_ENV === "production" ? invariant(true) : invariant(true, "ok");
+    `, {
+      importProcessPolyfill: true,
+    });
+
+    checkTransform(`
+      import { foo } from "bar";
+      import invariant from "ts-invariant";
+      invariant(true, "ok");
+    `, `
+      import { foo } from "bar";
+      import invariant from "ts-invariant";
+      process.env.NODE_ENV === "production" ? invariant(true) : invariant(true, "ok");
+    `);
   });
 });


### PR DESCRIPTION
Explicitly importing `process` in source code is likely to cause TypeScript warnings/errors if the `process` identifier is never used in source code.

Since `rollup-plugin-invariant` is responsible for injecting `process.env.NODE_ENV` expressions into the code at build time, it should also be responsible for importing the polyfill.

If `process.env.NODE_ENV` is later replaced by the minifier, the imported process identifier can be stripped from the bundle, ideally.

Should help with https://github.com/apollographql/apollo-client/issues/4665.